### PR TITLE
Add get_instance_commands CLI to extract per-instance test/eval/repo/env commands

### DIFF
--- a/swebench/harness/get_instance_commands.py
+++ b/swebench/harness/get_instance_commands.py
@@ -5,10 +5,19 @@ CLI to extract commands for one or more SWE-bench instance IDs.
 By default, prints only the test commands (the lines between START_TEST_OUTPUT and END_TEST_OUTPUT)
 for each instance. You can choose other sections with --section.
 
+Instance IDs can be provided directly with -i/--instance_ids, or via a JSON file containing
+an array of string IDs using --instance_ids_file.
+
 Usage:
+    # Direct IDs
     python -m swebench.harness.get_instance_commands -i django__django-15180 pytest-dev__pytest-10482
-    python -m swebench.harness.get_instance_commands -i ... --section eval
-    python -m swebench.harness.get_instance_commands -i ... --format json --output commands.json
+
+    # From a JSON file: ["django__django-15180", "pytest-dev__pytest-10482"]
+    python -m swebench.harness.get_instance_commands --instance_ids_file ids.json
+
+    # Change section and output format
+    python -m swebench.harness.get_instance_commands --instance_ids_file ids.json --section eval
+    python -m swebench.harness.get_instance_commands --instance_ids_file ids.json --format json --output commands.json
 """
 
 from __future__ import annotations
@@ -64,15 +73,45 @@ def get_instance_commands(instance: Dict, section: str = "test") -> Dict[str, Li
         raise ValueError(f"Unknown section: {section}")
 
 
+def _load_ids(instance_ids: List[str] | None, instance_ids_file: str | None) -> List[str]:
+    """
+    Combine IDs provided directly with IDs loaded from a JSON file.
+
+    The JSON file must contain an array of strings: ["repo__repo-123", "..."]
+    """
+    ids: List[str] = list(instance_ids or [])
+    if instance_ids_file:
+        with open(instance_ids_file, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, list) or not all(isinstance(x, str) for x in data):
+            raise ValueError("instance_ids_file must be a JSON array of strings")
+        ids.extend(data)
+    # de-duplicate while preserving order
+    seen = set()
+    unique_ids: List[str] = []
+    for x in ids:
+        if x not in seen:
+            unique_ids.append(x)
+            seen.add(x)
+    return unique_ids
+
+
 def main(
     dataset_name: str,
     split: str,
-    instance_ids: List[str],
+    instance_ids: List[str] | None,
+    instance_ids_file: str | None,
     section: str,
     fmt: str,
     output: str | None,
 ) -> None:
-    dataset = load_swebench_dataset(dataset_name, split, instance_ids)
+    # load IDs from CLI and JSON file
+    ids = _load_ids(instance_ids, instance_ids_file)
+    if not ids:
+        print("No instance IDs provided. Use -i/--instance_ids or --instance_ids_file.")
+        return
+
+    dataset = load_swebench_dataset(dataset_name, split, ids)
     if not dataset:
         print("No instances found for the given IDs.")
         return
@@ -126,8 +165,13 @@ if __name__ == "__main__":
         "-i",
         "--instance_ids",
         nargs="+",
-        required=True,
+        required=False,
         help="Instance IDs to process (space separated).",
+    )
+    parser.add_argument(
+        "--instance_ids_file",
+        type=str,
+        help="Path to JSON file containing an array of instance IDs.",
     )
     parser.add_argument(
         "--section",

--- a/swebench/harness/get_instance_commands.py
+++ b/swebench/harness/get_instance_commands.py
@@ -26,7 +26,7 @@ import json
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from typing import Dict, List
 
-from swebench.harness.constants import START_TEST_OUTPUT, END_TEST_OUTPUT
+from swebench.harness.constants import START_TEST_OUTPUT, END_TEST_OUTPUT, MAP_REPO_VERSION_TO_SPECS
 from swebench.harness.test_spec.test_spec import make_test_spec
 from swebench.harness.utils import load_swebench_dataset
 
@@ -42,6 +42,17 @@ def _extract_test_commands(eval_script_list: List[str]) -> List[str]:
         return []
 
 
+def _get_install_cmds(instance: Dict) -> List[str]:
+    """Return the install command(s) defined in the specs for this instance."""
+    specs = MAP_REPO_VERSION_TO_SPECS[instance["repo"]][instance["version"]]
+    install = specs.get("install")
+    if install is None:
+        return []
+    if isinstance(install, list):
+        return install
+    return [install]
+
+
 def get_instance_commands(instance: Dict, section: str = "test") -> Dict[str, List[str]] | List[str]:
     """
     Build the TestSpec for the instance and return commands for the requested section.
@@ -51,7 +62,8 @@ def get_instance_commands(instance: Dict, section: str = "test") -> Dict[str, Li
       - "eval" -> full eval script list
       - "repo" -> repository setup commands
       - "env"  -> environment setup commands
-      - "all"  -> dict with keys: env, repo, eval, test
+      - "install" -> install command(s) from specs
+      - "all"  -> dict with keys: env, repo, eval, test, install
     """
     ts = make_test_spec(instance)
     if section == "test":
@@ -62,12 +74,15 @@ def get_instance_commands(instance: Dict, section: str = "test") -> Dict[str, Li
         return ts.repo_script_list
     elif section == "env":
         return ts.env_script_list
+    elif section == "install":
+        return _get_install_cmds(instance)
     elif section == "all":
         return {
             "env": ts.env_script_list,
             "repo": ts.repo_script_list,
             "eval": ts.eval_script_list,
             "test": _extract_test_commands(ts.eval_script_list),
+            "install": _get_install_cmds(instance),
         }
     else:
         raise ValueError(f"Unknown section: {section}")
@@ -134,7 +149,7 @@ def main(
             print(f"Instance: {iid}")
             if section == "all":
                 assert isinstance(cmds, dict)
-                for key in ["env", "repo", "eval", "test"]:
+                for key in ["env", "repo", "eval", "test", "install"]:
                     print(f"  {key} commands:")
                     for c in cmds[key]:
                         print(f"    {c}")
@@ -175,7 +190,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--section",
-        choices=["test", "eval", "repo", "env", "all"],
+        choices=["test", "eval", "repo", "env", "install", "all"],
         default="test",
         help="Which commands to extract.",
     )

--- a/swebench/harness/get_instance_commands.py
+++ b/swebench/harness/get_instance_commands.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+CLI to extract commands for one or more SWE-bench instance IDs.
+
+By default, prints only the test commands (the lines between START_TEST_OUTPUT and END_TEST_OUTPUT)
+for each instance. You can choose other sections with --section.
+
+Usage:
+    python -m swebench.harness.get_instance_commands -i django__django-15180 pytest-dev__pytest-10482
+    python -m swebench.harness.get_instance_commands -i ... --section eval
+    python -m swebench.harness.get_instance_commands -i ... --format json --output commands.json
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from typing import Dict, List
+
+from swebench.harness.constants import START_TEST_OUTPUT, END_TEST_OUTPUT
+from swebench.harness.test_spec.test_spec import make_test_spec
+from swebench.harness.utils import load_swebench_dataset
+
+
+def _extract_test_commands(eval_script_list: List[str]) -> List[str]:
+    """Return only the test commands between START_TEST_OUTPUT and END_TEST_OUTPUT."""
+    try:
+        start = eval_script_list.index(f": '{START_TEST_OUTPUT}'") + 1
+        end = eval_script_list.index(f": '{END_TEST_OUTPUT}'")
+        return eval_script_list[start:end]
+    except ValueError:
+        # Markers not found; return empty list
+        return []
+
+
+def get_instance_commands(instance: Dict, section: str = "test") -> Dict[str, List[str]] | List[str]:
+    """
+    Build the TestSpec for the instance and return commands for the requested section.
+
+    section:
+      - "test" -> only the test commands (between markers)
+      - "eval" -> full eval script list
+      - "repo" -> repository setup commands
+      - "env"  -> environment setup commands
+      - "all"  -> dict with keys: env, repo, eval, test
+    """
+    ts = make_test_spec(instance)
+    if section == "test":
+        return _extract_test_commands(ts.eval_script_list)
+    elif section == "eval":
+        return ts.eval_script_list
+    elif section == "repo":
+        return ts.repo_script_list
+    elif section == "env":
+        return ts.env_script_list
+    elif section == "all":
+        return {
+            "env": ts.env_script_list,
+            "repo": ts.repo_script_list,
+            "eval": ts.eval_script_list,
+            "test": _extract_test_commands(ts.eval_script_list),
+        }
+    else:
+        raise ValueError(f"Unknown section: {section}")
+
+
+def main(
+    dataset_name: str,
+    split: str,
+    instance_ids: List[str],
+    section: str,
+    fmt: str,
+    output: str | None,
+) -> None:
+    dataset = load_swebench_dataset(dataset_name, split, instance_ids)
+    if not dataset:
+        print("No instances found for the given IDs.")
+        return
+
+    results: Dict[str, Dict[str, List[str]] | List[str]] = {}
+    for instance in dataset:
+        instance_id = instance["instance_id"]
+        results[instance_id] = get_instance_commands(instance, section)
+
+    if fmt == "json":
+        payload = json.dumps(results, indent=2)
+        if output:
+            with open(output, "w") as f:
+                f.write(payload)
+        else:
+            print(payload)
+    else:
+        # human-readable text
+        for iid, cmds in results.items():
+            print(f"Instance: {iid}")
+            if section == "all":
+                assert isinstance(cmds, dict)
+                for key in ["env", "repo", "eval", "test"]:
+                    print(f"  {key} commands:")
+                    for c in cmds[key]:
+                        print(f"    {c}")
+                print()
+            else:
+                assert isinstance(cmds, list)
+                for c in cmds:
+                    print(f"  {c}")
+                print()
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Extract commands for SWE-bench instance IDs.",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-d",
+        "--dataset_name",
+        default="SWE-bench/SWE-bench_Lite",
+        type=str,
+        help="Dataset name or path to JSON/JSONL file.",
+    )
+    parser.add_argument(
+        "-s", "--split", type=str, default="test", help="Dataset split."
+    )
+    parser.add_argument(
+        "-i",
+        "--instance_ids",
+        nargs="+",
+        required=True,
+        help="Instance IDs to process (space separated).",
+    )
+    parser.add_argument(
+        "--section",
+        choices=["test", "eval", "repo", "env", "all"],
+        default="test",
+        help="Which commands to extract.",
+    )
+    parser.add_argument(
+        "--format",
+        dest="fmt",
+        choices=["text", "json"],
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional path to write JSON output.",
+    )
+
+    args = parser.parse_args()
+    main(**vars(args))


### PR DESCRIPTION
Introduce a new CLI tool at swebench/harness/get_instance_commands.py that lets you fetch the exact commands to run tests for SWE-bench instances from the dataset/specs. This helps answer where the test commands come from for each instance, by exposing the commands that SWE-bench uses to run and evaluate each repo.

What it does:
- Builds a TestSpec for each specified instance (via make_test_spec) and exposes its command sections.
- Supports multiple sections:
  - test: only the test commands found between START_TEST_OUTPUT and END_TEST_OUTPUT markers
  - eval: the full eval script list
  - repo: repository setup commands
  - env: environment setup commands
  - all: a dictionary with env, repo, eval, and test sections
- The test commands are extracted by locating the markers in the eval_script_list; if markers aren’t found, an empty list is returned.
- Outputs can be printed in human-readable text or emitted as JSON. When using --format json, you can optionally write to a file with --output.

Why this helps:
- It directly exposes the exact commands to run for each instance, making it easy to reproduce or audit how SWE-bench runs tests for a given repo/instance.
- Bridges the gap between log parsing and the actual commands by presenting the underlying commands from the instance Spec.

How to use:
- Print test commands for specific instances:
  python -m swebench.harness.get_instance_commands -i django__django-15180 pytest-dev__pytest-10482
- Choose a different section (eval, repo, env, all):
  python -m swebench.harness.get_instance_commands -i django__django-15180 --section all
- Output as JSON (and optionally save to a file):
  python -m swebench.harness.get_instance_commands -i django__django-15180 --section test --format json --output commands.json
- You can specify dataset and split if needed (defaults are provided in the CLI):
  -d/--dataset_name, -s/--split

Implementation notes:
- Uses load_swebench_dataset to load the dataset for the requested instances and iterates through results.
- Returns a Python dict keyed by instance_id with the requested section data, or a nested dict when section is all.


---

> This pull request was co-created with Cosine Genie

Original Task: [SWE-bench/6vgcnnwa7v0g](https://cosine.sh/cosine/SWE-bench/task/6vgcnnwa7v0g)
Author: Alistair Pullen
